### PR TITLE
getStoredObject() could throw AccessDeniedException before all the locking logic occurs, but wasn't being caught.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle
+build

--- a/src/main/java/net/sf/webdav/methods/DoHead.java
+++ b/src/main/java/net/sf/webdav/methods/DoHead.java
@@ -65,14 +65,20 @@ public class DoHead extends AbstractMethod {
         String path = getRelativePath(req);
         LOG.trace("-- " + this.getClass().getName());
 
-        StoredObject so = _store.getStoredObject(transaction, path);
-        if (so == null) {
-            if (this._insteadOf404 != null && !_insteadOf404.trim().equals("")) {
-                path = this._insteadOf404;
-                so = _store.getStoredObject(transaction, this._insteadOf404);
-            }
-        } else
-            bUriExists = true;
+        StoredObject so;
+        try {
+            so = _store.getStoredObject(transaction, path);
+            if (so == null) {
+                if (this._insteadOf404 != null && !_insteadOf404.trim().equals("")) {
+                    path = this._insteadOf404;
+                    so = _store.getStoredObject(transaction, this._insteadOf404);
+                }
+            } else
+                bUriExists = true;
+        } catch (AccessDeniedException e) {
+            resp.sendError(WebdavStatus.SC_FORBIDDEN);
+            return;
+        }
 
         if (so != null) {
             if (so.isFolder()) {


### PR DESCRIPTION
If I want to deny access to a resource, throwing AccessDeniedException seems to be the proper way.

Throwing it from getContent() was one option, but if you do it that way, DoGet swallows the exception, so you get a 200 OK but with no content, not a 403.

Throwing it from getStoredObject() seems like a more general solution - when you think about it, sometimes you even want to hide the metadata anyway. (existence vs. non-existence can be information leakage too.) But throwing it from there resulted in the exception bubbling right out, instead of setting the status code appropriately. So this fixes that.
